### PR TITLE
Wrap Keystore in Quotes

### DIFF
--- a/lib/fastlane/plugin/android_keystore/actions/android_keystore_action.rb
+++ b/lib/fastlane/plugin/android_keystore/actions/android_keystore_action.rb
@@ -37,7 +37,7 @@ module Fastlane
         unless File.file?(keystore_path)
           keytool_parts = [
             "keytool -genkey -v",
-            "-keystore #{keystore_path}",
+            "-keystore '#{keystore_path}'",
             "-alias #{alias_name}",
             "-keyalg RSA -keysize 2048 -validity 10000",
             "-storepass #{password} ",


### PR DESCRIPTION
Wrap Keystore in quotes to ensure compatibility with paths containing spaces